### PR TITLE
Limit the captions' number of words

### DIFF
--- a/idk/resources/views/home.blade.php
+++ b/idk/resources/views/home.blade.php
@@ -11,9 +11,30 @@
                 <div class="card-body">
                     <form action="{{route('home')}}" method="POST" enctype="multipart/form-data">
                         {{ csrf_field() }} 
-                        <textarea name="body" rows="3" cols="25" class="form-control" placeholder="Enter your caption here,upload your picture, then press submit!"></textarea>
+                        <textarea name="body" id="caption" rows="3" cols="25" class="form-control" placeholder="Enter your caption here,upload your picture, then press submit!"></textarea>
                         <input type="file" name="image"/>
                         <input type="submit" name="upload" value="Upload"/>
+                        
+                        <script type="text/javascript">
+                            //get the text area element
+                            //keypress event for when user presses a key
+                            //add a function that keeps track of the input after a key is pressed
+                            document.getElementById("caption").addEventListener("keypress", function(event){
+
+                                //Split the words into different elements of an array when encountering at least one space character
+                                var words = this.value.split(/\s+/);
+                                //Get the number of words in that array
+                                var numWords = words.length;
+                                //Set the maximum number of words to write
+                                var maxWords = 250;
+
+                                //When maximum of words is exceeded
+                                if(numWords > maxWords){
+                                    //prevent further input
+                                    event.preventDefault();
+                                }
+                            });
+                        </script>
                     </form>
                 </div>
     


### PR DESCRIPTION
Fix #28 
added an id to the textbox for captions so that I could link it to and write a Javascript that limits the number of words written in the textbox designated for captions.
